### PR TITLE
兼容 BS 最新开发版

### DIFF
--- a/src/Controllers/PluginController.php
+++ b/src/Controllers/PluginController.php
@@ -70,7 +70,11 @@ class PluginController extends Controller
 
         //Start to download
         try {
-            Utils::download($url, $tmp_path);
+            if (version_compare(config('app.version'), '3.4.0', '>=')) {
+                file_put_contents($tmp_path, file_get_contents($url, false, $context));
+            } else {
+                Utils::download($url, $tmp_path);
+            }
         } catch (\Exception $e) {
             File::deleteDirectory($tmp_dir);
             return response()->json(['code' => 3]);


### PR DESCRIPTION
对于版本高于或等于 v3.4.0 的 BS，使用 ``file_get_contents()`` 和 ``file_put_contents()`` 替代 ``Utils::download()`` 下载插件压缩包。

### 为什么是“高于或等于”而不仅是“高于”？
在 BS 最新开发版（e36d395）的 ``config/app.php`` 文件中，标记的 BS 版本仍是 v3.4.0（而不是更高版本），但最新开发版中 Utils 类已经被废弃了。而 BS v3.5.0 尚未正式发布，此时若使用者未手动更改标记的版本，则仍会使用 ``Utils::download()`` 下载插件压缩包，造成插件市场报错。
![image](https://user-images.githubusercontent.com/16630630/43853007-5c40fc42-9b71-11e8-8a80-b6c9b61cb333.png)
这个方案已经在 LittleSkin 上进行了测试，成功安装了插件。
很惭愧，只做了一点微小的贡献。
感谢 @g-plane 的指导 :-)